### PR TITLE
Avoid wrong pattern matching in directory path of movie file

### DIFF
--- a/Movie_Data_Capture.py
+++ b/Movie_Data_Capture.py
@@ -24,18 +24,6 @@ from number_parser import get_number
 from core import core_main, core_main_no_net_op, moveFailedFolder, debug_print
 
 
-def check_update(local_version):
-    htmlcode = get_html("https://api.github.com/repos/yoshiko2/Movie_Data_Capture/releases/latest")
-    data = json.loads(htmlcode)
-    remote = int(data["tag_name"].replace(".", ""))
-    local_version = int(local_version.replace(".", ""))
-    if local_version < remote:
-        print("[*]" + ("* New update " + str(data["tag_name"]) + " *").center(54))
-        print("[*]" + "↓ Download ↓".center(54))
-        print("[*]https://github.com/yoshiko2/Movie_Data_Capture/releases")
-        print("[*]======================================================")
-
-
 def argparse_function(ver: str) -> typing.Tuple[str, str, str, str, bool, bool, str, str]:
     conf = config.getInstance()
     parser = argparse.ArgumentParser(epilog=f"Load Config file '{conf.ini_path}'.")
@@ -559,37 +547,19 @@ def main(args: tuple) -> Path:
                     ) if not single_file_path else ('-', 'Single File', '', '', ''))
           )
 
-    if conf.update_check():
-        try:
-            check_update(version)
-            # Download Mapping Table, parallel version
-            def fmd(f) -> typing.Tuple[str, Path]:
-                return ('https://raw.githubusercontent.com/yoshiko2/Movie_Data_Capture/master/MappingTable/' + f,
-                        Path.home() / '.local' / 'share' / 'mdc' / f)
+    # Mapping table no longer exist, thus simply copy ones in the repo directory if not exist
+    def fmd(f) -> typing.Tuple[str, Path]:
+        return (os.path.join(os.path.abspath(os.path.dirname(__file__)), "MappingTable", f),
+                Path.home() / '.local' / 'share' / 'mdc' / f)
 
-            map_tab = (fmd('mapping_actor.xml'), fmd('mapping_info.xml'), fmd('c_number.json'))
-            for k, v in map_tab:
-                if v.exists():
-                    if file_modification_days(str(v)) >= conf.mapping_table_validity():
-                        print("[+]Mapping Table Out of date! Remove", str(v))
-                        os.remove(str(v))
-            res = parallel_download_files(((k, v) for k, v in map_tab if not v.exists()))
-            for i, fp in enumerate(res, start=1):
-                if fp and len(fp):
-                    print(f"[+] [{i}/{len(res)}] Mapping Table Downloaded to {fp}")
-                else:
-                    print(f"[-] [{i}/{len(res)}] Mapping Table Download failed")
-        except:
-            print("[!]" + " WARNING ".center(54, "="))
-            print('[!]' + '-- GITHUB CONNECTION FAILED --'.center(54))
-            print('[!]' + 'Failed to check for updates'.center(54))
-            print('[!]' + '& update the mapping table'.center(54))
-            print("[!]" + "".center(54, "="))
-            try:
-                etree.parse(str(Path.home() / '.local' / 'share' / 'mdc' / 'mapping_actor.xml'))
-            except:
-                print('[!]' + "Failed to load mapping table".center(54))
-                print('[!]' + "".center(54, "="))
+    map_tab = (fmd('mapping_actor.xml'), fmd('mapping_info.xml'), fmd('c_number.json'))
+    os.makedirs(Path.home() / '.local' / 'share' / 'mdc', exist_ok=True)
+    for k, v in map_tab:
+        if not v.exists():
+            shutil.copyfile(k, v)
+            print(f"Mapping table initialized to: {v}")
+        else:
+            print(f"Mapping table already exists: {v}")
 
     create_failed_folder(conf.failed_folder())
 

--- a/core.py
+++ b/core.py
@@ -745,51 +745,52 @@ def core_main_no_net_op(movie_path, number):
     multi = False
     part = ''
     path = str(Path(movie_path).parent)
+    movie_filename = os.path.basename(movie_path)
 
-    if re.search(r'[-_]CD\d+', movie_path, re.IGNORECASE):
-        part = re.findall(r'[-_]CD\d+', movie_path, re.IGNORECASE)[0].upper()
+    if re.search(r'[-_]CD\d+', movie_filename, re.IGNORECASE):
+        part = re.findall(r'[-_]CD\d+', movie_filename, re.IGNORECASE)[0].upper()
         multi = True
-    if re.search(r'[-_]C(\.\w+$|-\w+)|\d+ch(\.\w+$|-\w+)', movie_path,
-                 re.I) or '中文' in movie_path or '字幕' in movie_path or ".chs" in movie_path or '.cht' in movie_path:
+    if re.search(r'[-_]C(\.\w+$|-\w+)|\d+ch(\.\w+$|-\w+)', movie_filename,
+                 re.I) or '中文' in movie_filename or '字幕' in movie_filename or ".chs" in movie_filename or '.cht' in movie_filename:
         cn_sub = True
         c_word = '-C'  # 中文字幕影片后缀
     uncensored = True if is_uncensored(number) else 0
-    if '流出' in movie_path or 'uncensored' in movie_path.lower() or 'leak' in movie_path.lower():
+    if '流出' in movie_filename or 'uncensored' in movie_filename.lower() or 'leak' in movie_filename.lower():
         leak_word = '-leak'  # 无码流出影片后缀
         leak = True
 
-    if 'hack'.upper() in str(movie_path).upper() or '破解' in movie_path:
+    if 'hack'.upper() in str(movie_filename).upper() or '破解' in movie_filename:
         hack = True
         hack_word = "-hack"
 
-    if '4k'.upper() in str(movie_path).upper() or '4k' in movie_path:
+    if '4k'.upper() in str(movie_filename).upper() or '4k' in movie_filename:
         _4k = True
 
-    if '.iso'.upper() in str(movie_path).upper() or '.iso' in movie_path:
+    if '.iso'.upper() in str(movie_filename).upper() or '.iso' in movie_filename:
         iso = True
 
-    if '-uc'.upper() in str(movie_path).upper():
+    if '-uc'.upper() in str(movie_filename).upper():
         hack = True
         hack_word = "-hack"
         cn_sub = True
         c_word = '-C'  # 中文字幕影片后缀
 
-    if '-u'.upper() in str(movie_path).upper():
+    if '-u'.upper() in str(movie_filename).upper():
         hack = True
         hack_word = "-hack"
 
-    if '-lc'.upper() in str(movie_path).upper():
+    if '-lc'.upper() in str(movie_filename).upper():
         leak_word = '-leak'  # 无码流出影片后缀
         leak = True
         cn_sub = True
         c_word = '-C'  # 中文字幕影片后缀
 
-    if '-l'.upper() in str(movie_path).upper():
+    if '-l'.upper() in str(movie_filename).upper():
         leak_word = '-leak'  # 无码流出影片后缀
         leak = True
     # try:
 
-    #     props = get_video_properties(movie_path)  # 判断是否为4K视频
+    #     props = get_video_properties(movie_filename)  # 判断是否为4K视频
     #     if props['width'] >= 4096 or props['height'] >= 2160:
     #         _4k = True
     # except:
@@ -882,45 +883,47 @@ def core_main(movie_path, number_th, oCC, specified_source=None, specified_url=N
     temp_leak_word = ''
     temp_c_word = ''
     temp_hack_word = ''
+
+    movie_filename = os.path.basename(movie_path)
     
-    if re.search(r'[-_]C(\.\w+$|-\w+)|\d+ch(\.\w+$|-\w+)', movie_path,
-                 re.I) or '中文' in movie_path or '字幕' in movie_path or ".chs" in movie_path or '.cht' in movie_path:
+    if re.search(r'[-_]C(\.\w+$|-\w+)|\d+ch(\.\w+$|-\w+)', movie_filename,
+                 re.I) or '中文' in movie_filename or '字幕' in movie_filename or ".chs" in movie_filename or '.cht' in movie_filename:
         cn_sub = True
         temp_c_word = '-C'
     
-    if '流出' in movie_path or 'uncensored' in movie_path.lower() or 'leak' in movie_path.lower():
+    if '流出' in movie_filename or 'uncensored' in movie_filename.lower() or 'leak' in movie_filename.lower():
         temp_leak_word = '-leak'
         leak = True
     else:
         leak = False
     
-    if 'hack'.upper() in str(movie_path).upper() or '破解' in movie_path:
+    if 'hack'.upper() in str(movie_filename).upper() or '破解' in movie_filename:
         hack = True
         temp_hack_word = "-hack"
     
-    if '4k'.upper() in str(movie_path).upper() or '4k' in movie_path:
+    if '4k'.upper() in str(movie_filename).upper() or '4k' in movie_filename:
         _4k = True
     
-    if '.iso'.upper() in str(movie_path).upper() or '.iso' in movie_path:
+    if '.iso'.upper() in str(movie_filename).upper() or '.iso' in movie_filename:
         iso = True
     
-    if '-uc'.upper() in str(movie_path).upper():
+    if '-uc'.upper() in str(movie_filename).upper():
         hack = True
         temp_hack_word = "-hack"
         cn_sub = True
         temp_c_word = '-C'
     
-    if '-u'.upper() in str(movie_path).upper():
+    if '-u'.upper() in str(movie_filename).upper():
         hack = True
         temp_hack_word = "-hack"
     
-    if '-lc'.upper() in str(movie_path).upper():
+    if '-lc'.upper() in str(movie_filename).upper():
         temp_leak_word = '-leak'
         leak = True
         cn_sub = True
         temp_c_word = '-C'
     
-    if '-l'.upper() in str(movie_path).upper():
+    if '-l'.upper() in str(movie_filename).upper():
         temp_leak_word = '-leak'
         leak = True
     
@@ -966,9 +969,9 @@ def core_main(movie_path, number_th, oCC, specified_source=None, specified_url=N
                         print('[+]Watermark added to existing poster')
                 
                 # 移动视频文件到输出目录
-                if re.search(r'[-_]CD\d+', movie_path, re.IGNORECASE):
+                if re.search(r'[-_]CD\d+', movie_filename, re.IGNORECASE):
                     multi_part = True
-                    part = re.findall(r'[-_]CD\d+', movie_path, re.IGNORECASE)[0].upper()
+                    part = re.findall(r'[-_]CD\d+', movie_filename, re.IGNORECASE)[0].upper()
                 
                 leak_word = temp_leak_word
                 c_word = temp_c_word
@@ -1001,11 +1004,12 @@ def core_main(movie_path, number_th, oCC, specified_source=None, specified_url=N
     imagecut = json_data.get('imagecut')
     tag = json_data.get('tag')
     # =======================================================================判断-C,-CD后缀
-    if re.search(r'[-_]CD\d+', movie_path, re.IGNORECASE):
+
+    if re.search('[-_]CD\d+', movie_filename, re.IGNORECASE):
         multi_part = True
-        part = re.findall(r'[-_]CD\d+', movie_path, re.IGNORECASE)[0].upper()
-    if re.search(r'[-_]C(\.\w+$|-\w+)|\d+ch(\.\w+$|-\w+)', movie_path,
-                 re.I) or '中文' in movie_path or '字幕' in movie_path:
+        part = re.findall('[-_]CD\d+', movie_filename, re.IGNORECASE)[0].upper()
+    if re.search(r'[-_]C(\.\w+$|-\w+)|\d+ch(\.\w+$|-\w+)', movie_filename,
+                 re.I) or '中文' in movie_filename or '字幕' in movie_filename:
         cn_sub = True
         c_word = '-C'  # 中文字幕影片后缀
 
@@ -1013,40 +1017,40 @@ def core_main(movie_path, number_th, oCC, specified_source=None, specified_url=N
     unce = json_data.get('无码')
     uncensored = int(unce) if isinstance(unce, bool) else int(is_uncensored(number))
 
-    if '流出' in movie_path or 'uncensored' in movie_path.lower() or 'leak' in movie_path.lower():
+    if '流出' in movie_filename or 'uncensored' in movie_filename.lower() or 'leak' in movie_filename.lower():
         liuchu = '流出'
         leak = True
         leak_word = '-leak'  # 流出影片后缀
     else:
         leak = False
 
-    if 'hack'.upper() in str(movie_path).upper() or '破解' in movie_path:
+    if 'hack'.upper() in str(movie_filename).upper() or '破解' in movie_filename:
         hack = True
         hack_word = "-hack"
 
-    if '4k'.upper() in str(movie_path).upper() or '4k' in movie_path:
+    if '4k'.upper() in str(movie_filename).upper() or '4k' in movie_filename:
         _4k = True
 
-    if '.iso'.upper() in str(movie_path).upper() or '.iso' in movie_path:
+    if '.iso'.upper() in str(movie_filename).upper() or '.iso' in movie_filename:
         iso = True
 
-    if '-uc'.upper() in str(movie_path).upper():
+    if '-uc'.upper() in str(movie_filename).upper():
         hack = True
         hack_word = "-hack"
         cn_sub = True
         c_word = '-C'  # 中文字幕影片后缀
 
-    if '-u'.upper() in str(movie_path).upper():
+    if '-u'.upper() in str(movie_filename).upper():
         hack = True
         hack_word = "-hack"
 
-    if '-lc'.upper() in str(movie_path).upper():
+    if '-lc'.upper() in str(movie_filename).upper():
         leak_word = '-leak'  # 无码流出影片后缀
         leak = True
         cn_sub = True
         c_word = '-C'  # 中文字幕影片后缀
 
-    if '-l'.upper() in str(movie_path).upper():
+    if '-l'.upper() in str(movie_filename).upper():
         leak_word = '-leak'  # 无码流出影片后缀
         leak = True
 
@@ -1059,7 +1063,7 @@ def core_main(movie_path, number_th, oCC, specified_source=None, specified_url=N
         tag.remove('无码破解')  # 从tag中移除'无码破解'
 
     # try:
-    #     props = get_video_properties(movie_path)  # 判断是否为4K视频
+    #     props = get_video_properties(movie_filename)  # 判断是否为4K视频
     #     if props['width'] >= 4096 or props['height'] >= 2160:
     #         _4k = True
     # except:


### PR DESCRIPTION
如果影片所在文件夹路径中包含如`-u`之类的字符串会导致误判为"破解"的情况
例如路径为
```
/srv/dev-disk-by-uuid-UUID/movie/ABC-123.mp4
```